### PR TITLE
Add fault and removed error & success gRPC functions

### DIFF
--- a/nmodule/grpcmarshal.go
+++ b/nmodule/grpcmarshal.go
@@ -31,8 +31,8 @@ type Marshaller interface {
 	GetNetworksByPluginName(pluginName string, opts ...*Opts) ([]*model.Network, error)
 	UpdateNetwork(uuid string, body *model.Network, opts ...*Opts) (*model.Network, error)
 	CountNetworks(body *dto.Filter, opts ...*Opts) (int, error)
-	UpdateNetworkErrors(uuid string, body *model.Network, opts ...*Opts) error
-	UpdateNetworkDescendantsErrors(networkUUID, message, messageLevel, messageCode string, withPoints bool, opts ...*Opts) error
+	UpdateNetworkFault(uuid string, body *model.CommonFault, opts ...*Opts) error
+	UpdateNetworkDescendantsFault(networkUUID string, body *model.CommonFault, withPoints bool, opts ...*Opts) error
 	UpsertNetworkMetaTags(uuid string, body []*model.NetworkMetaTag, opts ...*Opts) error
 	UpsertNetworkTags(uuid string, body []*model.Tag, opts ...*Opts) error
 	DeleteNetwork(uuid string, opts ...*Opts) error
@@ -47,8 +47,8 @@ type Marshaller interface {
 	GetOneDeviceByArgs(opts ...*Opts) (*model.Device, error)
 	CountDevices(body *dto.Filter, opts ...*Opts) (int, error)
 	UpdateDevice(uuid string, body *model.Device, opts ...*Opts) (*model.Device, error)
-	UpdateDeviceErrors(uuid string, body *model.Device, opts ...*Opts) error
-	UpdateDeviceDescendantsErrors(deviceUUID, message, messageLevel, messageCode string, opts ...*Opts) error
+	UpdateDeviceFault(uuid string, body *model.CommonFault, opts ...*Opts) error
+	UpdateDeviceDescendantsFault(deviceUUID string, body *model.CommonFault, opts ...*Opts) error
 	UpsertDeviceMetaTags(uuid string, body []*model.DeviceMetaTag, opts ...*Opts) error
 	UpsertDeviceTags(uuid string, body []*model.Tag, opts ...*Opts) error
 	DeleteDevice(uuid string, opts ...*Opts) error
@@ -67,8 +67,7 @@ type Marshaller interface {
 	UpdatePoint(uuid string, body *model.Point, opts ...*Opts) (*model.Point, error)
 	PointWrite(uuid string, body *dto.PointWriter, opts ...*Opts) (*dto.PointWriteResponse, error)
 	PointWriteByName(networkName, deviceName, pointName string, body *dto.PointWriter, opts ...*Opts) (*dto.PointWriteResponse, error)
-	UpdatePointErrors(uuid string, body *model.Point, opts ...*Opts) error
-	UpdatePointSuccess(uuid string, body *model.Point, opts ...*Opts) error
+	UpdatePointFault(uuid string, body *model.CommonFault, opts ...*Opts) error
 	UpsertPoint(uuid string, body *model.Point, opts ...*Opts) (*model.Point, error)
 	UpsertPointMetaTags(uuid string, body []*model.PointMetaTag, opts ...*Opts) error
 	UpsertPointTags(uuid string, body []*model.Tag, opts ...*Opts) error

--- a/nmodule/impldevices.go
+++ b/nmodule/impldevices.go
@@ -102,8 +102,8 @@ func (g *GRPCMarshaller) UpdateDevice(uuid string, body *model.Device, opts ...*
 	return device, nil
 }
 
-func (g *GRPCMarshaller) UpdateDeviceErrors(uuid string, body *model.Device, opts ...*Opts) error {
-	api := fmt.Sprintf("/api/devices/%s/error", uuid)
+func (g *GRPCMarshaller) UpdateDeviceFault(uuid string, body *model.CommonFault, opts ...*Opts) error {
+	api := fmt.Sprintf("/api/devices/%s/fault", uuid)
 	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, body, opts...)
 	if err != nil {
 		return err
@@ -111,16 +111,9 @@ func (g *GRPCMarshaller) UpdateDeviceErrors(uuid string, body *model.Device, opt
 	return nil
 }
 
-func (g *GRPCMarshaller) UpdateDeviceDescendantsErrors(deviceUUID, message, messageLevel, messageCode string, opts ...*Opts) error {
-	api := fmt.Sprintf("/api/devices/%s/error/descendants", deviceUUID)
-	device := &model.Device{
-		CommonFault: model.CommonFault{
-			Message:      message,
-			MessageLevel: messageLevel,
-			MessageCode:  messageCode,
-		},
-	}
-	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, device, opts...)
+func (g *GRPCMarshaller) UpdateDeviceDescendantsFault(deviceUUID string, body *model.CommonFault, opts ...*Opts) error {
+	api := fmt.Sprintf("/api/devices/%s/fault/descendants", deviceUUID)
+	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, body, opts...)
 	return err
 }
 

--- a/nmodule/implnetworks.go
+++ b/nmodule/implnetworks.go
@@ -159,8 +159,8 @@ func (g *GRPCMarshaller) UpdateNetwork(uuid string, body *model.Network, opts ..
 	return network, nil
 }
 
-func (g *GRPCMarshaller) UpdateNetworkErrors(uuid string, body *model.Network, opts ...*Opts) error {
-	api := fmt.Sprintf("/api/networks/%s/error", uuid)
+func (g *GRPCMarshaller) UpdateNetworkFault(uuid string, body *model.CommonFault, opts ...*Opts) error {
+	api := fmt.Sprintf("/api/networks/%s/fault", uuid)
 	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, body, opts...)
 	if err != nil {
 		return err
@@ -168,21 +168,14 @@ func (g *GRPCMarshaller) UpdateNetworkErrors(uuid string, body *model.Network, o
 	return nil
 }
 
-func (g *GRPCMarshaller) UpdateNetworkDescendantsErrors(networkUUID, message, messageLevel, messageCode string, withPoints bool, opts ...*Opts) error {
-	api := fmt.Sprintf("/api/networks/%s/error/descendants", networkUUID)
-	network := &model.Network{
-		CommonFault: model.CommonFault{
-			Message:      message,
-			MessageLevel: messageLevel,
-			MessageCode:  messageCode,
-		},
-	}
+func (g *GRPCMarshaller) UpdateNetworkDescendantsFault(networkUUID string, body *model.CommonFault, withPoints bool, opts ...*Opts) error {
+	api := fmt.Sprintf("/api/networks/%s/fault/descendants", networkUUID)
 	if len(opts) > 0 {
 		opts[0].Args = &nargs.Args{WithPoints: withPoints}
 	} else {
 		opts = append(opts, &Opts{Args: &nargs.Args{WithPoints: withPoints}})
 	}
-	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, network, opts...)
+	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, body, opts...)
 	return err
 }
 

--- a/nmodule/implpoints.go
+++ b/nmodule/implpoints.go
@@ -153,17 +153,8 @@ func (g *GRPCMarshaller) PointWriteByName(networkName, deviceName, pointName str
 	return pwr, nil
 }
 
-func (g *GRPCMarshaller) UpdatePointErrors(uuid string, body *model.Point, opts ...*Opts) error {
-	api := fmt.Sprintf("/api/points/%s/error", uuid)
-	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, body, opts...)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (g *GRPCMarshaller) UpdatePointSuccess(uuid string, body *model.Point, opts ...*Opts) error {
-	api := fmt.Sprintf("/api/points/%s/success", uuid)
+func (g *GRPCMarshaller) UpdatePointFault(uuid string, body *model.CommonFault, opts ...*Opts) error {
+	api := fmt.Sprintf("/api/points/%s/fault", uuid)
 	_, err := g.CallDBHelperWithParser(nhttp.PATCH, api, body, opts...)
 	if err != nil {
 		return err


### PR DESCRIPTION
ROS ticket: https://github.com/NubeIO/rubix-os/pull/810

### Summary

- It has an elegant way of updating fault messages
- Removed functions
   - UpdateNetworkErrors
   - UpdateNetworkDescendantsErrors
   - UpdateDeviceErrors
   - UpdateDeviceDescendantsErrors
   - UpdatePointErrors
   - UpdatePointSuccess
- Added functions
   - UpdateNetworkFault
   - UpdateNetworkDescendantsFault
   - UpdateDeviceFault
   - UpdateDeviceDescendantsFault
   - UpdatePointFault
- Older `lib-module-go` works fine with newer ROS, but will eventually be deprecated
- Newer `lib-module-go` needs new ROS