### PR TITLE
Upgrade nubeio-rubix-lib-models-go v1.15.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/NubeIO/lib-date v0.0.6
 	github.com/NubeIO/lib-networking v0.1.0
 	github.com/NubeIO/lib-system v0.0.3
-	github.com/NubeIO/nubeio-rubix-lib-models-go v1.14.16
+	github.com/NubeIO/nubeio-rubix-lib-models-go v1.15.2
 	github.com/hashicorp/go-plugin v1.4.9
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/NubeIO/lib-systemctl-go v0.3.1/go.mod h1:P/Ij5pgTtjNnp/TQhsvwipk8sv+5
 github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.7 h1:QKgcOjDkVujyAXWK+OysVFnQKzpZx335vGPG95UNXuI=
 github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.7/go.mod h1:oLI6n9wuko0KIEzrLc8saOquiQvtMUUBrUjXf0TLDVQ=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.0.4/go.mod h1:A1BPuc3UpE1EF3ugdf+8QIIKTT8s3eK+pfUcheJX2JM=
-github.com/NubeIO/nubeio-rubix-lib-models-go v1.14.16 h1:reRxRxUob5kHCxuySPodUcKEfO8uA7NPbL9a58CsYVw=
-github.com/NubeIO/nubeio-rubix-lib-models-go v1.14.16/go.mod h1:tTdOPP0bMUe6FR/zYu3B/TXkG7j1z8Pz+ViNh9dTNl4=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.15.2 h1:vXsg857ZqHQGw8tSl1XXYOZkslFPVL5VFMtRZno+nAM=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.15.2/go.mod h1:tTdOPP0bMUe6FR/zYu3B/TXkG7j1z8Pz+ViNh9dTNl4=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/THREATINT/go-net v1.2.10/go.mod h1:4n3ITWyUUfaEp8JNAompTT+PuPANXL9i9TyOUijGnwk=


### PR DESCRIPTION
### Summary:

- Upgraded `nubeio-rubix-lib-models-go`  to  `v1.15.2`.